### PR TITLE
Update

### DIFF
--- a/LAZY_RULES/*Surge_GLOBAL.conf
+++ b/LAZY_RULES/*Surge_GLOBAL.conf
@@ -1,22 +1,32 @@
-# 2018年02月19日08:51:18
+# 2018年04月04日 11:44:03
 
 [General]
-# warning, notify, info, verbose
 loglevel = notify
 dns-server = 119.29.29.29, 182.254.116.116, 8.8.8.8, 8.8.4.4, system
-skip-proxy = 127.0.0.1, 192.168.0.0/16, 172.16.0.0/12, 100.64.0.0/10, 10.0.0.0/8, localhost, *.local, captive.apple.com
-
-ipv6 = true
-external-controller-access = PASSWORD@0.0.0.0:6170
-allow-wifi-access = false
+skip-proxy = 127.0.0.1,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,100.64.0.0/10,17.0.0.0/8,localhost,*.local,::ffff:0.0.0.0/1,::ffff:128.0.0.0/1
 
 // iOS
-bypass-system = true
-bypass-tun = 192.168.0.0/16, 172.16.0.0/12, 100.64.0.0/10, 10.0.0.0/8, 17.0.0.0/8
+allow-wifi-access = true
+
+external-controller-access = PASSWORD@0.0.0.0:6170
 
 // macOS
 interface = 0.0.0.0
 socks-interface = 0.0.0.0
+port = 8888
+socks-port = 8889
+
+enhanced-mode-by-rule = false
+
+// Auto
+allow-udp-proxy = true
+collapse-policy-group-items = true
+exclude-simple-hostnames = true
+hide-apple-request = true
+hide-crashlytics-request = true
+ipv6 = true
+replica = false
+use-keyword-filter = false
 
 [Proxy]
 ↕️ 全局直连 = direct

--- a/LAZY_RULES/Surge.conf
+++ b/LAZY_RULES/Surge.conf
@@ -1,21 +1,32 @@
-# 2018年02月19日 08:48:03
+# 2018年04月04日 11:44:03
 
 [General]
 loglevel = notify
 dns-server = 119.29.29.29, 182.254.116.116, 8.8.8.8, 8.8.4.4, system
-skip-proxy = 127.0.0.1, 192.168.0.0/16, 172.16.0.0/12, 100.64.0.0/10, 10.0.0.0/8, localhost, *.local
-
-ipv6 = true
-external-controller-access = PASSWORD@0.0.0.0:6170
-allow-wifi-access = false
+skip-proxy = 127.0.0.1,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,100.64.0.0/10,17.0.0.0/8,localhost,*.local,::ffff:0.0.0.0/1,::ffff:128.0.0.0/1
 
 // iOS
-bypass-system = true
-bypass-tun = 192.168.0.0/16, 172.16.0.0/12, 100.64.0.0/10, 10.0.0.0/8, 17.0.0.0/8
+allow-wifi-access = true
+
+external-controller-access = PASSWORD@0.0.0.0:6170
 
 // macOS
 interface = 0.0.0.0
 socks-interface = 0.0.0.0
+port = 8888
+socks-port = 8889
+
+enhanced-mode-by-rule = false
+
+// Auto
+allow-udp-proxy = true
+collapse-policy-group-items = true
+exclude-simple-hostnames = true
+hide-apple-request = true
+hide-crashlytics-request = true
+ipv6 = true
+replica = false
+use-keyword-filter = false
 
 [Proxy]
 DIRECT = direct


### PR DESCRIPTION
新增skip-proxy：微信
修改allow-wifi-access默认为开启
删除bypass-tun（已经不再支持或需要）
修改macOS版的端口以解决部分应用程序的兼容问题
增加部分开关