### PR TITLE
解決非英文情形的Wikiwand 頁面匹配問題。

### DIFF
--- a/规则片段集/功能性规则集/维基百科(Wikipedia)排版优化.txt
+++ b/规则片段集/功能性规则集/维基百科(Wikipedia)排版优化.txt
@@ -8,4 +8,4 @@ DOMAIN-SUFFIX,wikiwand.com,Proxy
 [URL Rewrite]
 ^https://zh.(m.)?wikipedia.org/(zh-hans|zh-sg|zh-cn|zh(?=/)) http://www.wikiwand.com/zh 302
 ^https://zh.(m.)?wikipedia.org/zh-[a-zA-Z]{2,} http://www.wikiwand.com/zh-hant 302
-^https://.*.(m.)?wikipedia.org/wiki http://www.wikiwand.com/en 302
+^https://(\w*).(m.)?wikipedia.org/wiki http://www.wikiwand.com/$1 302


### PR DESCRIPTION
該Commit 解決了對於非英文頁面跳轉到Wikiwand時候可能失敗的小錯誤。測試過德文、西班牙文，希望您能夠合併。