### PR TITLE
对科研出版商重新分类，增加 Elsevier 旗下 scopus.com 网站

### DIFF
--- a/Rulesets/Custom/academic.list
+++ b/Rulesets/Custom/academic.list
@@ -2,18 +2,17 @@
 # 此规则适用于学校校园网已经购买论文网站版权，通过校园网的直连才能具备该免费下载的权限。
 # 此规则使用前应先咨询校方，是否有购买版权。若没有，此规则无用处。更适合大学生及以上学学历学生使用。
 
-## 中国知网
+# 中国知网
 DOMAIN-KEYWORD,cnki.net
 
-## 万方
+# 万方
 DOMAIN-KEYWORD,wanfangdata
 
-## 法律数据库
+# 法律数据库
 DOMAIN-KEYWORD,pkulaw
 DOMAIN-KEYWORD,westlawchina
 
-## 国际环境生态学术出版商
-DOMAIN-SUFFIX,sciencedirect.com
+# SCI 综合
 DOMAIN-SUFFIX,researchgate.net
 DOMAIN-SUFFIX,springer.com
 DOMAIN-SUFFIX,wiley.com
@@ -25,3 +24,10 @@ DOMAIN-SUFFIX,ieee.org
 DOMAIN-SUFFIX,nature.com
 DOMAIN-SUFFIX,sciencemag.org
 DOMAIN-SUFFIX,osapublishing.org
+
+## Elsevier 旗下
+DOMAIN-SUFFIX,scopus.com
+DOMAIN-SUFFIX,sciencedirect.com
+
+## 告别出版商绑架
+DOMAIN-KEYWORD,sci-hub,Proxy

--- a/规则片段集/自选规则集/学术网站.txt
+++ b/规则片段集/自选规则集/学术网站.txt
@@ -3,18 +3,17 @@
 
 [Rule]
 
-## 中国知网
+# 中国知网
 DOMAIN-KEYWORD,cnki.net,DIRECT
 
-## 万方
+# 万方
 DOMAIN-KEYWORD,wanfangdata,DIRECT
 
-## 法律数据库
+# 法律数据库
 DOMAIN-KEYWORD,pkulaw,DIRECT
 DOMAIN-KEYWORD,westlawchina,DIRECT
 
-## 国际环境生态学术出版商
-DOMAIN-SUFFIX,sciencedirect.com,DIRECT
+# SCI 综合
 DOMAIN-SUFFIX,researchgate.net,DIRECT
 DOMAIN-SUFFIX,springer.com,DIRECT
 DOMAIN-SUFFIX,wiley.com,DIRECT
@@ -27,5 +26,10 @@ DOMAIN-SUFFIX,nature.com,DIRECT
 DOMAIN-SUFFIX,sciencemag.org,DIRECT
 DOMAIN-SUFFIX,osapublishing.org,DIRECT
 
+## Elsevier 旗下
+DOMAIN-SUFFIX,scopus.com,DIRECT
+DOMAIN-SUFFIX,sciencedirect.com,DIRECT
+
 ## 告别出版商绑架
 DOMAIN-KEYWORD,sci-hub,Proxy
+


### PR DESCRIPTION
- 对科研出版商重新分类
- 增加 Elsevier 旗下 scopus.com 网站