### PR TITLE
Delete "Proxy" for the last rule

### DIFF
--- a/Rulesets/Custom/academic.list
+++ b/Rulesets/Custom/academic.list
@@ -36,4 +36,4 @@ DOMAIN-KEYWORD,deepdyve
 DOMAIN-KEYWORD,els-cdn
 
 ## 告别出版商绑架
-DOMAIN-KEYWORD,sci-hub,Proxy
+DOMAIN-KEYWORD,sci-hub


### PR DESCRIPTION
The last rule ends with "proxy," causing Surge to crash.