### PR TITLE
增加了 YouTube Music 独立规则；增加了仅限日本 IP 访问的 DMM 网站匹配规则

### DIFF
--- a/Rulesets/App/stream/YouTube_Music.list
+++ b/Rulesets/App/stream/YouTube_Music.list
@@ -1,0 +1,6 @@
+# YouTube Music for iOS
+USER-AGENT,*YouTubeMusic* 
+USER-AGENT,*com.google.ios.youtubemusic*
+
+#YT-Music, An unofficial but fancy client of YouTube Music for Mac
+PROCESS-NAME,YT Music

--- a/Rulesets/Custom/adult_Japan.list
+++ b/Rulesets/Custom/adult_Japan.list
@@ -1,0 +1,2 @@
+DOMAIN-SUFFIX,dmm.co.jp
+DOMAIN-KEYWORD,dmm


### PR DESCRIPTION
## 1. YouTube Music

YouTube Music 不像 YouTube 可以在全世界大多数地区使用，它仅在部分地区运营。例如为了更快的观影体验，我们会选择 HK 节点访问 YouTube，但是 YT Music 无法在 HK 使用，因此有必要对 YouTube Music 单独设置节点。

但是因为目前的个人能力和工具限制，似乎很难完美的对网页版 YouTube Music 设置规则，因为很多资源地址与 YouTube 主站通用。但是通过 UA 和 PROCESS-NAME 对软件设置代理是可行的。虽然目前 Mac 端没有官方 YT Music 的客户端，但是开源的 [YouTube-Music](https://github.com/steve228uk/YouTube-Music) 是一个不错的替代。

综上，对 YouTube iOS 端和 YouTube-Music Mac 端设置了代理。

## 2. DMM (NSFW)

作为 NSFW 大站，虽然在 DMM 购买影片的玩家通常是少数，但是作为正版网站，DMM 可以提供很多有用的影片信息，包括不限于发行日期，制作人，演员表和**封面**，因此也是收藏家的刚需网站 ;-)

但 DMM 只针对日本地区提供服务，因此如果想要有良好的访问体验，需要对 DMM 单独设置日本节点。