### PR TITLE
Remove unencrypted nameserver & add encrypted one

### DIFF
--- a/LAZY_RULES/clash.yaml
+++ b/LAZY_RULES/clash.yaml
@@ -66,14 +66,12 @@ dns:
   #   - localhost.ptlogin2.qq.com
 
   nameserver:
-    - 1.2.4.8
-    - 114.114.114.114
-    - 223.5.5.5
+    - https://i.233py.com/dns-query
     - tls://13800000000.rubyfish.cn:853
     #- https://13800000000.rubyfish.cn/
      
   fallback: # 与 nameserver 内的服务器列表同时发起请求，当规则符合 GEOIP 在 CN 以外时，fallback 列表内的域名服务器生效。
-    - tls://13800000000.rubyfish.cn:853
+    - tls://ea-dns.rubyfish.cn:853
     - tls://1.0.0.1:853
     - tls://dns.google:853
 


### PR DESCRIPTION
Since all connections send their DNS query to `nameserver`s, using nameservers with bad reputation, especially unencrypted ones, is vulnerable for privacy. And they are in fact optional. So I replace them with better acknowledged nameservers.

Considering the need of resolving domestic IP addresses for domestic websites, maybe you can add `https://dns.alidns.com/dns-query` or `dot.360.cn` (not reputable though, at least useful to evade ISP's attack). But I believe what I propose is enough.