### PR TITLE
适配新版配置文件

### DIFF
--- a/LAZY_RULES/clash.yaml
+++ b/LAZY_RULES/clash.yaml
@@ -105,7 +105,7 @@ dns:
 #   若要了解更多关于 DoH/DoT 相关技术，请自行查阅规范文档。
 
 
-Proxy:
+proxies:
 # shadowsocks
 # 所支持的加密方式与 go-shadowsocks2 保持一致
 # 支持加密方式： 
@@ -198,7 +198,7 @@ Proxy:
       # mode: http # 或 tls
       # host: bing.com
 
-Proxy Group:
+proxy-groups:
 # url-test 可以自动选择与指定 URL 测速后，延迟最短的服务器
   - name: "auto"
     type: url-test
@@ -239,7 +239,7 @@ Proxy Group:
       - vmess1
       - auto
 
-Rule:
+rules:
 # Apple
   - DOMAIN,safebrowsing.urlsec.qq.com,DIRECT # 如果您并不信任此服务提供商或防止其下载消耗过多带宽资源，可以进入 Safari 设置，关闭 Fraudulent Website Warning 功能，并使用 REJECT 策略。
   - DOMAIN,safebrowsing.googleapis.com,DIRECT # 如果您并不信任此服务提供商或防止其下载消耗过多带宽资源，可以进入 Safari 设置，关闭 Fraudulent Website Warning 功能，并使用 REJECT 策略。


### PR DESCRIPTION
Clash最新版移除了前向兼容代码 [官方Wiki](https://github.com/Dreamacro/clash/wiki/breaking-changes-in-1.0.0)

- 不再解析 "Proxy" "Proxy Group" "Rule" 字段 而 使用 "proxies" "proxy-groups" "rules"
- 不再解析 "rule-provider" 而使用 "rule-providers"
- 不再解析 Shadowsocks 协议的 "obfs", "obfs-host" 而 使用 "plugin" "plugin-opts"
- 不再解析 "FINAL" "SOURCE-IP-CIDR" 而 使用 "MATCH" "SRC-IP-CIDR"