### PR TITLE
Add acm.org into academic-direct.list

### DIFF
--- a/Rulesets/Surge/Custom/academic-direct.list
+++ b/Rulesets/Surge/Custom/academic-direct.list
@@ -44,5 +44,8 @@ DOMAIN-SUFFIX,oup.com
 ## Springer 旗下
 DOMAIN-SUFFIX,springernature.com
 
+# ACM (Association for Computing Machinery)
+DOMAIN-SUFFIX,acm.org
+
 ## JSTOR 旗下
 DOMAIN-SUFFIX,jstor.org


### PR DESCRIPTION
acm.org and dl.acm.org is used for downloading papers

Related Issue #131