### PR TITLE
QuantumultX 自动添加 Google CN 相关的 MitM 主机名

### DIFF
--- a/Rulesets/Quantumult/rewrite.list
+++ b/Rulesets/Quantumult/rewrite.list
@@ -1,1 +1,2 @@
+hostname = *.g.cn, *.google.cn
 ^https?://(www.)?(g|google).cn url 302 https://www.google.com


### PR DESCRIPTION
根据 [Rewrite 的官方样例](https://raw.githubusercontent.com/crossutility/Quantumult-X/master/sample-import-rewrite.txt)，可以定义一行 `hostname` ，设置的主机名会自动添加到 MitM 设置中。