### PR TITLE
修改 clash fake-ip-filter

### DIFF
--- a/LAZY_RULES/Clash_Premium.yaml
+++ b/LAZY_RULES/Clash_Premium.yaml
@@ -101,23 +101,10 @@ dns:
     - 'time.*.edu.cn'
     - 'time.*.apple.com'
 
-    - 'time1.*.com'
-    - 'time2.*.com'
-    - 'time3.*.com'
-    - 'time4.*.com'
-    - 'time5.*.com'
-    - 'time6.*.com'
-    - 'time7.*.com'
+    - 'time*.*.com'
 
     - 'ntp.*.com'
-    - 'ntp.*.com'
-    - 'ntp1.*.com'
-    - 'ntp2.*.com'
-    - 'ntp3.*.com'
-    - 'ntp4.*.com'
-    - 'ntp5.*.com'
-    - 'ntp6.*.com'
-    - 'ntp7.*.com'
+    - 'ntp*.*.com'
 
     - '*.time.edu.cn'
     - '*.ntp.org.cn'
@@ -159,7 +146,9 @@ dns:
     - '+.xboxlive.com'
     # === Other ===
     ## QQ Quick Login
-    - 'localhost.ptlogin2.qq.com'
+    ## - localhost.ptplugin2.qq.com
+    ## - localhost.sec.qq.com
+    - 'localhost.*.qq.com'
     ## Golang
     - 'proxy.golang.org'
     ## STUN Server

--- a/LAZY_RULES/clash.yaml
+++ b/LAZY_RULES/clash.yaml
@@ -101,23 +101,10 @@ dns:
     - 'time.*.edu.cn'
     - 'time.*.apple.com'
 
-    - 'time1.*.com'
-    - 'time2.*.com'
-    - 'time3.*.com'
-    - 'time4.*.com'
-    - 'time5.*.com'
-    - 'time6.*.com'
-    - 'time7.*.com'
+    - 'time*.*.com'
 
     - 'ntp.*.com'
-    - 'ntp.*.com'
-    - 'ntp1.*.com'
-    - 'ntp2.*.com'
-    - 'ntp3.*.com'
-    - 'ntp4.*.com'
-    - 'ntp5.*.com'
-    - 'ntp6.*.com'
-    - 'ntp7.*.com'
+    - 'ntp*.*.com'
 
     - '*.time.edu.cn'
     - '*.ntp.org.cn'
@@ -159,7 +146,9 @@ dns:
     - '+.xboxlive.com'
     # === Other ===
     ## QQ Quick Login
-    - 'localhost.ptlogin2.qq.com'
+    ## - localhost.ptplugin2.qq.com
+    ## - localhost.sec.qq.com
+    - 'localhost.*.qq.com'
     ## Golang
     - 'proxy.golang.org'
     ## STUN Server


### PR DESCRIPTION
QQ 快速登录有 `localhost.ptplugin2.qq.com` 和 `localhost.sec.qq.com` 两个指向 localhost 的域名 补充完整
另外顺便简化了 `timeX.*.com` 和 `ntpX.*.com` 我不确定这样好不好用 但是看下面是可以用多个星号的 如果有问题可以帮我改掉