### PR TITLE
增加Netflix代理检测节点

### DIFF
--- a/Rulesets/Clash/App/stream/Netflix.yaml
+++ b/Rulesets/Clash/App/stream/Netflix.yaml
@@ -1,3 +1,4 @@
 payload:
   - DOMAIN-KEYWORD,netflix
   - DOMAIN-KEYWORD,nflx
+  - DOMAIN-SUFFIX,us-west-2.amazonaws.com

--- a/Rulesets/Quantumult/App/stream/Netflix.list
+++ b/Rulesets/Quantumult/App/stream/Netflix.list
@@ -2,3 +2,4 @@ user-agent,Argo*,proxy
 
 host-keyword,netflix,proxy
 host-keyword,nflx,proxy
+host-suffix,us-west-2.amazonaws.com,proxy

--- a/Rulesets/Surge/App/stream/Netflix.list
+++ b/Rulesets/Surge/App/stream/Netflix.list
@@ -2,3 +2,4 @@ USER-AGENT,Argo*
 
 DOMAIN-KEYWORD,netflix
 DOMAIN-KEYWORD,nflx
+DOMAIN-SUFFIX,us-west-2.amazonaws.com

--- a/规则片段集/App 规则集/流媒体/Netflix.txt
+++ b/规则片段集/App 规则集/流媒体/Netflix.txt
@@ -3,3 +3,4 @@ USER-AGENT,Argo*,Proxy
 
 DOMAIN-KEYWORD,netflix,Proxy
 DOMAIN-KEYWORD,nflx,Proxy
+DOMAIN-SUFFIX,us-west-2.amazonaws.com,Proxy


### PR DESCRIPTION
近期Netflix在AWS美西增加了一组代理检测节点，URL地址如下：
https://dualstack.apiproxy-device-prod-nlb-*-********************.us-west-2.amazonaws.com
其中URL中有2组*号，第一组表示数字0-9（大概率为3，小概率为2），第二组为长度为16的十六进制字符串（有一定随机性，有兴趣可以自行搜集一下）。
如果通过iOS/Android端升级后的app观看Netflix，且观看Netflix的线路中使用了分流，就会有一定概率会出现网络无法连接的提示。

以上文本非原创。