### PR TITLE
Update Shadowrocket.conf

### DIFF
--- a/LAZY_RULES/Shadowrocket.conf
+++ b/LAZY_RULES/Shadowrocket.conf
@@ -106,7 +106,6 @@ DOMAIN-SUFFIX,le.com,DIRECT
 DOMAIN-SUFFIX,lecloud.com,DIRECT
 DOMAIN-SUFFIX,lemicp.com,DIRECT
 DOMAIN-SUFFIX,licdn.com,DIRECT
-DOMAIN-SUFFIX,linkedin.com,DIRECT
 DOMAIN-SUFFIX,luoo.net,DIRECT
 DOMAIN-SUFFIX,meituan.com,DIRECT
 DOMAIN-SUFFIX,meituan.net,DIRECT
@@ -225,6 +224,7 @@ DOMAIN-SUFFIX,youtu.be,Proxy
 DOMAIN-KEYWORD,whatsapp,Proxy
 
 # 国外网站
+DOMAIN-SUFFIX,linkedin.com,Proxy
 DOMAIN-SUFFIX,9to5mac.com,Proxy
 DOMAIN-SUFFIX,abpchina.org,Proxy
 DOMAIN-SUFFIX,adblockplus.org,Proxy


### PR DESCRIPTION
linkedin.com需要强制走代理 否则会跳转linkedin.cn 猎头们没法工作了