### PR TITLE
修复美区播客浏览页加载&更新quanx news规则

### DIFF
--- a/Rulesets/Clash/Basic/Apple-proxy.yaml
+++ b/Rulesets/Clash/Basic/Apple-proxy.yaml
@@ -9,3 +9,4 @@ payload:
   - DOMAIN-SUFFIX,apps.apple.com
   - DOMAIN-SUFFIX,blobstore.apple.com
   - DOMAIN,cvws.icloud-content.com
+  - DOMAIN-SUFFIX,podcasts.apple.com

--- a/Rulesets/Quantumult/Basic/Apple-News.list
+++ b/Rulesets/Quantumult/Basic/Apple-News.list
@@ -4,5 +4,11 @@
 
 host-suffix,ls.apple.com,proxy
 user-agent,AppleNews*,proxy
-user-agent,News*,proxy
+user-agent,News,proxy
+user-agent,com.apple.news*
+host-suffix,apple.news
+host,news-assets.apple.com
+host,news-client.apple.com
+host,news-edge.apple.com
+host,news-events.apple.com
 host,apple.comscoreresearch.com,proxy

--- a/Rulesets/Quantumult/Basic/Apple-proxy.list
+++ b/Rulesets/Quantumult/Basic/Apple-proxy.list
@@ -8,3 +8,4 @@ host,itunes.apple.com,proxy
 host-suffix,apps.apple.com,proxy
 host-suffix,blobstore.apple.com,proxy
 host,cvws.icloud-content.com,proxy
+host-suffix,podcasts.apple.com,proxy


### PR DESCRIPTION
quanx user-agent规则好像不生效（已测试启用mitm与非启用两种情况），所以手动抓包把几个常用的域名加入规则中，使用测试下来基本无问题。clash则无此问题，所以没有改动clash的news规则。
美区播客页面，之前走的direct，显示目前无法连接，本次更新让他强制走规则后，选择对应区域路线即可正常使用