### PR TITLE
修复美区播客浏览页加载问题&更新quanx news规则

### DIFF
--- a/Rulesets/Clash/Basic/Apple-proxy.yaml
+++ b/Rulesets/Clash/Basic/Apple-proxy.yaml
@@ -9,3 +9,4 @@ payload:
   - DOMAIN-SUFFIX,apps.apple.com
   - DOMAIN-SUFFIX,blobstore.apple.com
   - DOMAIN,cvws.icloud-content.com
+  - DOMAIN-SUFFIX,podcasts.apple.com

--- a/Rulesets/Quantumult/Basic/Apple-News.list
+++ b/Rulesets/Quantumult/Basic/Apple-News.list
@@ -4,5 +4,11 @@
 
 host-suffix,ls.apple.com,proxy
 user-agent,AppleNews*,proxy
-user-agent,News*,proxy
+user-agent,News,proxy
+user-agent,com.apple.news*,proxy
+host-suffix,apple.news,proxy
+host,news-assets.apple.com,proxy
+host,news-client.apple.com,proxy
+host,news-edge.apple.com,proxy
+host,news-events.apple.com,proxy
 host,apple.comscoreresearch.com,proxy

--- a/Rulesets/Quantumult/Basic/Apple-proxy.list
+++ b/Rulesets/Quantumult/Basic/Apple-proxy.list
@@ -8,3 +8,4 @@ host,itunes.apple.com,proxy
 host-suffix,apps.apple.com,proxy
 host-suffix,blobstore.apple.com,proxy
 host,cvws.icloud-content.com,proxy
+host-suffix,podcasts.apple.com,proxy


### PR DESCRIPTION
quanx的user-agent好像没有效果（在开启了mitm于非启用情况下都做了测试），所以抓包把一些域名加入了规则当中，clash则工作正常，没有此问题，clash的规则故没有更新。
美区的播客浏览页走的是direct，显示目前无法连接，抓包把对应的域名加入规则后测试可正常使用（需有你对应区域的落地ip）。