### PR TITLE
更新Apple News规则

### DIFF
--- a/Rulesets/Quantumult/Basic/Apple-News.list
+++ b/Rulesets/Quantumult/Basic/Apple-News.list
@@ -4,5 +4,10 @@
 
 host-suffix,ls.apple.com,proxy
 user-agent,AppleNews*,proxy
-user-agent,News*,proxy
+user-agent,com.apple.news*,proxy
+host-suffix,apple.news,proxy
+host,news-assets.apple.com,proxy
+host,news-client.apple.com,proxy
+host,news-edge.apple.com,proxy
+host,news-events.apple.com,proxy
 host,apple.comscoreresearch.com,proxy


### PR DESCRIPTION
iOS上news部分功能没有解锁，比如听电台，部分新闻加载不出，抓包后把相关域名加入规则列表中，经测试无问题