### PR TITLE
更新Apple News规则

### DIFF
--- a/Rulesets/Quantumult/Basic/Apple-News.list
+++ b/Rulesets/Quantumult/Basic/Apple-News.list
@@ -2,7 +2,11 @@
 ## iPhone 和 蜂窝数据的 iPad 必须要开启飞行模式才可以使用，因为系统会检测 SIM 卡运营商
 ## Mac 和 非蜂窝数据机型的 iPad 可以在使用规则片段后直接使用 Apple News
 
+host,gateway.icloud.com,proxy
 host-suffix,ls.apple.com,proxy
-user-agent,AppleNews*,proxy
-user-agent,News*,proxy
+host-suffix,apple.news,proxy
+host,news-assets.apple.com,proxy
+host,news-client.apple.com,proxy
+host,news-edge.apple.com,proxy
+host,news-events.apple.com,proxy
 host,apple.comscoreresearch.com,proxy


### PR DESCRIPTION
quan x 抓包后未抓到user-agnet相关包，移除了这两条规则，添加了抓包到常用的域名进规则列表，测试可正常访问。